### PR TITLE
Fix the repo for Node.js

### DIFF
--- a/env_vars/base.yml
+++ b/env_vars/base.yml
@@ -9,7 +9,7 @@ application_log_dir: "{{ virtualenv_path }}/logs"
 application_log_file: "{{ application_log_dir }}/gunicorn_supervisor.log"
 
 # Node.js related settings, see https://github.com/nodesource/distributions#debinstall for possible values
-distro: trusty
+distro: precise
 node_js_version: node_5.x
 
 git_repo: https://github.com/lupyanlab/telephone.git


### PR DESCRIPTION
Previously I've set the repo for wrong Ubuntu distro (at least, for Vagrant box).

Please, note, that now default distro (for the purpose of Node.js repo) is Ubuntu Precise. If you are using different Ubuntu distro for your main server, you, probably, should decline this pull request, set the right distro to the base.yml and then overwrite it with `precise` in `env_vars/vagrant.yml`
